### PR TITLE
connect textract and openai to the API route

### DIFF
--- a/frontend/src/components/ImageUploader.tsx
+++ b/frontend/src/components/ImageUploader.tsx
@@ -32,7 +32,14 @@ const ImageUploader = () => {
   const handleDeployClick = async () => {
     if (images) {
       try {
-        await sendImageToApi(images, AWS_TEXTRACT_API_URL);
+        const response = await sendImageToApi(images, AWS_TEXTRACT_API_URL)
+        const text = await response.text()
+        if (response.status !== 200) {
+          console.log(`${response.status} Failed to analyze the contract: ${text}`)
+          throw new Error(text)
+        }
+        // Display the result
+        console.log(`Contract analyzed successfully: ${text}`)
         toast({
           title: "Message sent successfully",
         });


### PR DESCRIPTION
Yhdistin noi bäkkärihommat nyt tohon API routeen. Jätin tonne serverille noita console.logeja viel toistaseks. Toi openai apikutsu kestää semi kauan. Jos ei striimata sitä vastausta, tonne fronttii ois hyvä kehittää joku loading state systeemi kun odotellaan vastausta. Seuraavaks pitäis saada toi vastaus johonki näkyviin. Ei myöskään toistaseks validoida mitenkään tota lähetettävää dataa frontissa, joten voi lähettää esim pyynnön ilman kuvia.